### PR TITLE
Fix `number().min()` example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ storage.theme.set('light');
 storage.theme.set('sepia'); // Argument of type '"sepia"' is not assignable to parameter of type '"light" | "dark"'
 
 const age = storage.age.get(); // age is number
-storage.age.set(19); // throws zod error
+storage.age.set(17); // throws zod error
 ```
 
 ## Features


### PR DESCRIPTION
In the [Get Started](https://github.com/sharry/zod-storage/blob/master/README.md#get-started) section of the readme, `schema` is defined with the constraint `age` being at minimum `18`. That would mean that the declaration `storage.age.set(19)` wouldn't throw a zod error as it respects the aforementioned constraint.

This PR changes that value to `17`, so that it would lead to throwing the error.